### PR TITLE
test: Adds scram auth testing

### DIFF
--- a/auth/Scram.go
+++ b/auth/Scram.go
@@ -26,9 +26,6 @@ package auth
 
 import (
 	"bytes"
-	"crypto/hmac"
-	"crypto/rand"
-	"encoding/base64"
 	"fmt"
 	"hash"
 	"strconv"
@@ -63,10 +60,6 @@ type Scram struct {
 	saltedPass  []byte
 	authMsg     bytes.Buffer
 }
-
-// Need both because Haystack seems to switch between them for different parts.
-var b64Std = base64.StdEncoding
-var b64Uri = base64.RawURLEncoding // No padding
 
 // NewScram returns a new SCRAM-* client with the provided hash algorithm.
 //
@@ -128,13 +121,11 @@ func (c *Scram) Step(in []byte) bool {
 
 func (c *Scram) step1(in []byte) error {
 	if len(c.clientNonce) == 0 {
-		const nonceLen = 16
-		buf := make([]byte, nonceLen+b64Uri.EncodedLen(nonceLen))
-		if _, err := rand.Read(buf[:nonceLen]); err != nil {
-			return fmt.Errorf("cannot read random SCRAM-SHA-256 nonce from operating system: %v", err)
+		nonce, err := scramGenerateNonce()
+		if err != nil {
+			return err
 		}
-		c.clientNonce = buf[nonceLen:]
-		b64Uri.Encode(c.clientNonce, buf[:nonceLen])
+		c.clientNonce = nonce
 	}
 	c.authMsg.WriteString("n=")
 	escaper.WriteString(&c.authMsg, c.user)
@@ -179,7 +170,7 @@ func (c *Scram) step2(in []byte) error {
 	if err != nil {
 		return fmt.Errorf("server sent an invalid SCRAM-SHA-256 iteration count: %q", fields[2])
 	}
-	c.saltPassword(salt, iterCount)
+	c.saltedPass = scramSaltPassword(c.newHash, c.pass, salt, iterCount)
 
 	c.authMsg.WriteString(",c=biws,r=")
 	c.authMsg.Write(c.serverNonce)
@@ -187,7 +178,7 @@ func (c *Scram) step2(in []byte) error {
 	c.out.WriteString("c=biws,r=")
 	c.out.Write(c.serverNonce)
 	c.out.WriteString(",p=")
-	c.out.Write(c.clientProof())
+	c.out.Write(scramClientProof(c.newHash, c.saltedPass, c.authMsg.Bytes()))
 	return nil
 }
 
@@ -203,58 +194,8 @@ func (c *Scram) step3(in []byte) error {
 	} else if !isv {
 		return fmt.Errorf("unsupported SCRAM-SHA-256 final message from server: %q", in)
 	}
-	if !bytes.Equal(c.serverSignature(), fields[0][2:]) {
+	if !bytes.Equal(scramServerSignature(c.newHash, c.saltedPass, c.authMsg.Bytes()), fields[0][2:]) {
 		return fmt.Errorf("cannot authenticate SCRAM-SHA-256 server signature: %q", fields[0][2:])
 	}
 	return nil
-}
-
-func (c *Scram) saltPassword(salt []byte, iterCount int) {
-	mac := hmac.New(c.newHash, []byte(c.pass))
-	mac.Write(salt)
-	mac.Write([]byte{0, 0, 0, 1})
-	ui := mac.Sum(nil)
-	hi := make([]byte, len(ui))
-	copy(hi, ui)
-	for i := 1; i < iterCount; i++ {
-		mac.Reset()
-		mac.Write(ui)
-		mac.Sum(ui[:0])
-		for j, b := range ui {
-			hi[j] ^= b
-		}
-	}
-	c.saltedPass = hi
-}
-
-func (c *Scram) clientProof() []byte {
-	mac := hmac.New(c.newHash, c.saltedPass)
-	mac.Write([]byte("Client Key"))
-	clientKey := mac.Sum(nil)
-	hash := c.newHash()
-	hash.Write(clientKey)
-	storedKey := hash.Sum(nil)
-	mac = hmac.New(c.newHash, storedKey)
-	mac.Write(c.authMsg.Bytes())
-	clientProof := mac.Sum(nil)
-	for i, b := range clientKey {
-		clientProof[i] ^= b
-	}
-	clientProof64 := make([]byte, b64Std.EncodedLen(len(clientProof)))
-	b64Std.Encode(clientProof64, clientProof)
-	return clientProof64
-}
-
-func (c *Scram) serverSignature() []byte {
-	mac := hmac.New(c.newHash, c.saltedPass)
-	mac.Write([]byte("Server Key"))
-	serverKey := mac.Sum(nil)
-
-	mac = hmac.New(c.newHash, serverKey)
-	mac.Write(c.authMsg.Bytes())
-	serverSignature := mac.Sum(nil)
-
-	encoded := make([]byte, b64Std.EncodedLen(len(serverSignature)))
-	b64Std.Encode(encoded, serverSignature)
-	return encoded
 }

--- a/auth/ScramServer.go
+++ b/auth/ScramServer.go
@@ -2,8 +2,6 @@ package auth
 
 import (
 	"bytes"
-	"crypto/hmac"
-	"crypto/rand"
 	"fmt"
 	"hash"
 	"strconv"
@@ -161,15 +159,15 @@ func (s *ScramServer) step2(in []byte) error {
 		return fmt.Errorf("client sent an unexpected SCRAM combined nonce: got %q, want %q", combinedNonce, expectedNonce)
 	}
 
-	s.saltPassword(s.salt, s.iterCount)
+	s.saltedPass = scramSaltPassword(s.newHash, s.pass, s.salt, s.iterCount)
 	s.authMsg.WriteString(",c=biws,r=")
 	s.authMsg.Write(combinedNonce)
-	if !bytes.Equal(fields[2][2:], s.clientProof()) {
+	if !bytes.Equal(fields[2][2:], scramClientProof(s.newHash, s.saltedPass, s.authMsg.Bytes())) {
 		return fmt.Errorf("client sent an invalid SCRAM proof: %q", fields[2][2:])
 	}
 
 	s.out.WriteString("v=")
-	s.out.Write(s.serverSignature())
+	s.out.Write(scramServerSignature(s.newHash, s.saltedPass, s.authMsg.Bytes()))
 	return nil
 }
 
@@ -186,74 +184,4 @@ func (s *ScramServer) serverFirstMessage() []byte {
 	serverFirst.WriteString(",i=")
 	serverFirst.WriteString(strconv.Itoa(s.iterCount))
 	return serverFirst.Bytes()
-}
-
-func (s *ScramServer) saltPassword(salt []byte, iterCount int) {
-	mac := hmac.New(s.newHash, []byte(s.pass))
-	mac.Write(salt)
-	mac.Write([]byte{0, 0, 0, 1})
-	ui := mac.Sum(nil)
-	hi := make([]byte, len(ui))
-	copy(hi, ui)
-	for i := 1; i < iterCount; i++ {
-		mac.Reset()
-		mac.Write(ui)
-		mac.Sum(ui[:0])
-		for j, b := range ui {
-			hi[j] ^= b
-		}
-	}
-	s.saltedPass = hi
-}
-
-func (s *ScramServer) clientProof() []byte {
-	mac := hmac.New(s.newHash, s.saltedPass)
-	mac.Write([]byte("Client Key"))
-	clientKey := mac.Sum(nil)
-	hash := s.newHash()
-	hash.Write(clientKey)
-	storedKey := hash.Sum(nil)
-	mac = hmac.New(s.newHash, storedKey)
-	mac.Write(s.authMsg.Bytes())
-	clientProof := mac.Sum(nil)
-	for i, b := range clientKey {
-		clientProof[i] ^= b
-	}
-	clientProof64 := make([]byte, b64Std.EncodedLen(len(clientProof)))
-	b64Std.Encode(clientProof64, clientProof)
-	return clientProof64
-}
-
-func (s *ScramServer) serverSignature() []byte {
-	mac := hmac.New(s.newHash, s.saltedPass)
-	mac.Write([]byte("Server Key"))
-	serverKey := mac.Sum(nil)
-
-	mac = hmac.New(s.newHash, serverKey)
-	mac.Write(s.authMsg.Bytes())
-	serverSignature := mac.Sum(nil)
-
-	encoded := make([]byte, b64Std.EncodedLen(len(serverSignature)))
-	b64Std.Encode(encoded, serverSignature)
-	return encoded
-}
-
-func scramGenerateNonce() ([]byte, error) {
-	const nonceLen = 16
-	buf := make([]byte, nonceLen+b64Uri.EncodedLen(nonceLen))
-	if _, err := rand.Read(buf[:nonceLen]); err != nil {
-		return nil, fmt.Errorf("cannot read random SCRAM nonce from operating system: %v", err)
-	}
-	nonce := buf[nonceLen:]
-	b64Uri.Encode(nonce, buf[:nonceLen])
-	return nonce, nil
-}
-
-func scramGenerateSalt() ([]byte, error) {
-	const saltLen = 16
-	salt := make([]byte, saltLen)
-	if _, err := rand.Read(salt); err != nil {
-		return nil, fmt.Errorf("cannot read random SCRAM salt from operating system: %v", err)
-	}
-	return salt, nil
 }

--- a/auth/ScramServer.go
+++ b/auth/ScramServer.go
@@ -1,0 +1,259 @@
+package auth
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/rand"
+	"fmt"
+	"hash"
+	"strconv"
+	"strings"
+)
+
+const scramDefaultIterations = 4096
+
+var unescaper = strings.NewReplacer("=2C", ",", "=3D", "=")
+
+// ScramServer implements the server side of a SCRAM-* conversation.
+type ScramServer struct {
+	newHash func() hash.Hash
+
+	user string
+	pass string
+	step int
+	out  bytes.Buffer
+	err  error
+
+	clientNonce []byte
+	serverNonce []byte
+	salt        []byte
+	iterCount   int
+	saltedPass  []byte
+	authMsg     bytes.Buffer
+}
+
+// NewScramServer returns a new SCRAM-* server with the provided hash algorithm.
+func NewScramServer(newHash func() hash.Hash, user, pass string) *ScramServer {
+	s := &ScramServer{
+		newHash: newHash,
+		user:    user,
+		pass:    pass,
+	}
+	s.out.Grow(256)
+	s.authMsg.Grow(256)
+	return s
+}
+
+// Out returns the data to be sent to the client in the current step.
+func (s *ScramServer) Out() []byte {
+	if s.out.Len() == 0 {
+		return nil
+	}
+	return s.out.Bytes()
+}
+
+// Err returns the error that occurred, or nil if there were no errors.
+func (s *ScramServer) Err() error {
+	return s.err
+}
+
+// SetNonce sets the server nonce to the provided value.
+func (s *ScramServer) SetNonce(nonce []byte) {
+	s.serverNonce = nonce
+}
+
+// SetSalt sets the salt to the provided value.
+func (s *ScramServer) SetSalt(salt []byte) {
+	s.salt = salt
+}
+
+// SetIterations sets the SCRAM iteration count.
+func (s *ScramServer) SetIterations(iter int) {
+	s.iterCount = iter
+}
+
+// Step processes the incoming data from the client and makes the next round of
+// data for the client available via ScramServer.Out. Step returns false if
+// there are no errors and more data is still expected.
+func (s *ScramServer) Step(in []byte) bool {
+	s.out.Reset()
+	if s.step > 1 || s.err != nil {
+		return false
+	}
+	s.step++
+	switch s.step {
+	case 1:
+		s.err = s.step1(in)
+	case 2:
+		s.err = s.step2(in)
+	}
+	return s.step > 1 || s.err != nil
+}
+
+func (s *ScramServer) step1(in []byte) error {
+	if !bytes.HasPrefix(in, []byte("n,,")) {
+		return fmt.Errorf("expected SCRAM client first message to start with %q: %q", "n,,", in)
+	}
+	clientFirstBare := in[len("n,,"):]
+	fields := bytes.Split(clientFirstBare, []byte(","))
+	if len(fields) != 2 {
+		return fmt.Errorf("expected 2 fields in first SCRAM client message, got %d: %q", len(fields), in)
+	}
+	if !bytes.HasPrefix(fields[0], []byte("n=")) {
+		return fmt.Errorf("client sent an invalid SCRAM username: %q", fields[0])
+	}
+	if !bytes.HasPrefix(fields[1], []byte("r=")) || len(fields[1]) < 3 {
+		return fmt.Errorf("client sent an invalid SCRAM nonce: %q", fields[1])
+	}
+
+	user := unescaper.Replace(string(fields[0][2:]))
+	if user != s.user {
+		return fmt.Errorf("unexpected SCRAM username: %q", user)
+	}
+
+	s.clientNonce = append(s.clientNonce[:0], fields[1][2:]...)
+	if len(s.serverNonce) == 0 {
+		nonce, err := scramGenerateNonce()
+		if err != nil {
+			return err
+		}
+		s.serverNonce = nonce
+	}
+	if len(s.salt) == 0 {
+		salt, err := scramGenerateSalt()
+		if err != nil {
+			return err
+		}
+		s.salt = salt
+	}
+	if s.iterCount <= 0 {
+		s.iterCount = scramDefaultIterations
+	}
+
+	s.authMsg.Write(clientFirstBare)
+	serverFirst := s.serverFirstMessage()
+	s.authMsg.WriteByte(',')
+	s.authMsg.Write(serverFirst)
+	s.out.Write(serverFirst)
+	return nil
+}
+
+func (s *ScramServer) step2(in []byte) error {
+	fields := bytes.Split(in, []byte(","))
+	if len(fields) != 3 {
+		return fmt.Errorf("expected 3 fields in final SCRAM client message, got %d: %q", len(fields), in)
+	}
+	if !bytes.Equal(fields[0], []byte("c=biws")) {
+		return fmt.Errorf("client sent an invalid SCRAM channel binding: %q", fields[0])
+	}
+	if !bytes.HasPrefix(fields[1], []byte("r=")) || len(fields[1]) < 3 {
+		return fmt.Errorf("client sent an invalid SCRAM combined nonce: %q", fields[1])
+	}
+	if !bytes.HasPrefix(fields[2], []byte("p=")) || len(fields[2]) < 3 {
+		return fmt.Errorf("client sent an invalid SCRAM proof: %q", fields[2])
+	}
+
+	combinedNonce := fields[1][2:]
+	expectedNonce := make([]byte, 0, len(s.clientNonce)+len(s.serverNonce))
+	expectedNonce = append(expectedNonce, s.clientNonce...)
+	expectedNonce = append(expectedNonce, s.serverNonce...)
+	if !bytes.Equal(combinedNonce, expectedNonce) {
+		return fmt.Errorf("client sent an unexpected SCRAM combined nonce: got %q, want %q", combinedNonce, expectedNonce)
+	}
+
+	s.saltPassword(s.salt, s.iterCount)
+	s.authMsg.WriteString(",c=biws,r=")
+	s.authMsg.Write(combinedNonce)
+	if !bytes.Equal(fields[2][2:], s.clientProof()) {
+		return fmt.Errorf("client sent an invalid SCRAM proof: %q", fields[2][2:])
+	}
+
+	s.out.WriteString("v=")
+	s.out.Write(s.serverSignature())
+	return nil
+}
+
+func (s *ScramServer) serverFirstMessage() []byte {
+	serverFirst := new(bytes.Buffer)
+	serverFirst.Grow(256)
+	serverFirst.WriteString("r=")
+	serverFirst.Write(s.clientNonce)
+	serverFirst.Write(s.serverNonce)
+	serverFirst.WriteString(",s=")
+	encodedSalt := make([]byte, b64Std.EncodedLen(len(s.salt)))
+	b64Std.Encode(encodedSalt, s.salt)
+	serverFirst.Write(encodedSalt)
+	serverFirst.WriteString(",i=")
+	serverFirst.WriteString(strconv.Itoa(s.iterCount))
+	return serverFirst.Bytes()
+}
+
+func (s *ScramServer) saltPassword(salt []byte, iterCount int) {
+	mac := hmac.New(s.newHash, []byte(s.pass))
+	mac.Write(salt)
+	mac.Write([]byte{0, 0, 0, 1})
+	ui := mac.Sum(nil)
+	hi := make([]byte, len(ui))
+	copy(hi, ui)
+	for i := 1; i < iterCount; i++ {
+		mac.Reset()
+		mac.Write(ui)
+		mac.Sum(ui[:0])
+		for j, b := range ui {
+			hi[j] ^= b
+		}
+	}
+	s.saltedPass = hi
+}
+
+func (s *ScramServer) clientProof() []byte {
+	mac := hmac.New(s.newHash, s.saltedPass)
+	mac.Write([]byte("Client Key"))
+	clientKey := mac.Sum(nil)
+	hash := s.newHash()
+	hash.Write(clientKey)
+	storedKey := hash.Sum(nil)
+	mac = hmac.New(s.newHash, storedKey)
+	mac.Write(s.authMsg.Bytes())
+	clientProof := mac.Sum(nil)
+	for i, b := range clientKey {
+		clientProof[i] ^= b
+	}
+	clientProof64 := make([]byte, b64Std.EncodedLen(len(clientProof)))
+	b64Std.Encode(clientProof64, clientProof)
+	return clientProof64
+}
+
+func (s *ScramServer) serverSignature() []byte {
+	mac := hmac.New(s.newHash, s.saltedPass)
+	mac.Write([]byte("Server Key"))
+	serverKey := mac.Sum(nil)
+
+	mac = hmac.New(s.newHash, serverKey)
+	mac.Write(s.authMsg.Bytes())
+	serverSignature := mac.Sum(nil)
+
+	encoded := make([]byte, b64Std.EncodedLen(len(serverSignature)))
+	b64Std.Encode(encoded, serverSignature)
+	return encoded
+}
+
+func scramGenerateNonce() ([]byte, error) {
+	const nonceLen = 16
+	buf := make([]byte, nonceLen+b64Uri.EncodedLen(nonceLen))
+	if _, err := rand.Read(buf[:nonceLen]); err != nil {
+		return nil, fmt.Errorf("cannot read random SCRAM nonce from operating system: %v", err)
+	}
+	nonce := buf[nonceLen:]
+	b64Uri.Encode(nonce, buf[:nonceLen])
+	return nonce, nil
+}
+
+func scramGenerateSalt() ([]byte, error) {
+	const saltLen = 16
+	salt := make([]byte, saltLen)
+	if _, err := rand.Read(salt); err != nil {
+		return nil, fmt.Errorf("cannot read random SCRAM salt from operating system: %v", err)
+	}
+	return salt, nil
+}

--- a/auth/ScramServer_test.go
+++ b/auth/ScramServer_test.go
@@ -1,0 +1,84 @@
+package auth
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScramClientServerHandshake(t *testing.T) {
+	client := NewScram(sha256.New, "test", "test")
+	client.SetNonce([]byte("clientnonce"))
+
+	server := NewScramServer(sha256.New, "test", "test")
+	server.SetNonce([]byte("servernonce"))
+	server.SetSalt([]byte("salt-for-tests"))
+	server.SetIterations(4096)
+
+	var clientIn []byte
+	for !client.Step(clientIn) {
+		serverDone := server.Step(client.Out())
+		assert.Nil(t, server.Err())
+		clientIn = server.Out()
+		if serverDone {
+			break
+		}
+	}
+
+	assert.Nil(t, client.Err())
+	assert.Nil(t, server.Err())
+	assert.Equal(t, "v=2BuVkVpguahLEJ+D5hifYQOF+3GxZnOoqQejYRDA8IU=", string(server.Out()))
+	assert.True(t, client.Step(server.Out()))
+	assert.Nil(t, client.Err())
+}
+
+func TestScramServerInvalidUsername(t *testing.T) {
+	server := NewScramServer(sha256.New, "test", "test")
+	server.SetNonce([]byte("servernonce"))
+	server.SetSalt([]byte("salt-for-tests"))
+	server.SetIterations(4096)
+
+	done := server.Step([]byte("n,,n=wrong,r=clientnonce"))
+	assert.True(t, done)
+	assert.EqualError(t, server.Err(), `unexpected SCRAM username: "wrong"`)
+}
+
+func TestScramServerInvalidProof(t *testing.T) {
+	server := NewScramServer(sha256.New, "test", "test")
+	server.SetNonce([]byte("servernonce"))
+	server.SetSalt([]byte("salt-for-tests"))
+	server.SetIterations(4096)
+
+	assert.False(t, server.Step([]byte("n,,n=test,r=clientnonce")))
+	assert.Nil(t, server.Err())
+
+	clientFinal := []byte("c=biws,r=clientnonceservernonce,p=invalid")
+	done := server.Step(clientFinal)
+	assert.True(t, done)
+	assert.Error(t, server.Err())
+	assert.True(t, strings.Contains(server.Err().Error(), "invalid SCRAM proof"))
+}
+
+func TestScramServerInvalidCombinedNonce(t *testing.T) {
+	server := NewScramServer(sha256.New, "test", "test")
+	server.SetNonce([]byte("servernonce"))
+	server.SetSalt([]byte("salt-for-tests"))
+	server.SetIterations(4096)
+
+	assert.False(t, server.Step([]byte("n,,n=test,r=clientnonce")))
+	assert.Nil(t, server.Err())
+
+	client := NewScram(sha256.New, "test", "test")
+	client.SetNonce([]byte("clientnonce"))
+	assert.False(t, client.Step(nil))
+	assert.False(t, client.Step(server.Out()))
+
+	clientFinal := bytes.Replace(client.Out(), []byte("clientnonceservernonce"), []byte("clientnoncewrongnonce"), 1)
+	done := server.Step(clientFinal)
+	assert.True(t, done)
+	assert.Error(t, server.Err())
+	assert.True(t, strings.Contains(server.Err().Error(), "unexpected SCRAM combined nonce"))
+}

--- a/auth/scram_helpers.go
+++ b/auth/scram_helpers.go
@@ -1,0 +1,83 @@
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"hash"
+)
+
+// Need both because Haystack seems to switch between them for different parts.
+var b64Std = base64.StdEncoding
+var b64Uri = base64.RawURLEncoding // No padding
+
+func scramSaltPassword(newHash func() hash.Hash, password string, salt []byte, iterCount int) []byte {
+	mac := hmac.New(newHash, []byte(password))
+	mac.Write(salt)
+	mac.Write([]byte{0, 0, 0, 1})
+	ui := mac.Sum(nil)
+	hi := make([]byte, len(ui))
+	copy(hi, ui)
+	for i := 1; i < iterCount; i++ {
+		mac.Reset()
+		mac.Write(ui)
+		mac.Sum(ui[:0])
+		for j, b := range ui {
+			hi[j] ^= b
+		}
+	}
+	return hi
+}
+
+func scramClientProof(newHash func() hash.Hash, saltedPass []byte, authMsg []byte) []byte {
+	mac := hmac.New(newHash, saltedPass)
+	mac.Write([]byte("Client Key"))
+	clientKey := mac.Sum(nil)
+	hash := newHash()
+	hash.Write(clientKey)
+	storedKey := hash.Sum(nil)
+	mac = hmac.New(newHash, storedKey)
+	mac.Write(authMsg)
+	clientProof := mac.Sum(nil)
+	for i, b := range clientKey {
+		clientProof[i] ^= b
+	}
+	clientProof64 := make([]byte, b64Std.EncodedLen(len(clientProof)))
+	b64Std.Encode(clientProof64, clientProof)
+	return clientProof64
+}
+
+func scramServerSignature(newHash func() hash.Hash, saltedPass []byte, authMsg []byte) []byte {
+	mac := hmac.New(newHash, saltedPass)
+	mac.Write([]byte("Server Key"))
+	serverKey := mac.Sum(nil)
+
+	mac = hmac.New(newHash, serverKey)
+	mac.Write(authMsg)
+	serverSignature := mac.Sum(nil)
+
+	encoded := make([]byte, b64Std.EncodedLen(len(serverSignature)))
+	b64Std.Encode(encoded, serverSignature)
+	return encoded
+}
+
+func scramGenerateNonce() ([]byte, error) {
+	const nonceLen = 16
+	buf := make([]byte, nonceLen+b64Uri.EncodedLen(nonceLen))
+	if _, err := rand.Read(buf[:nonceLen]); err != nil {
+		return nil, fmt.Errorf("cannot read random SCRAM nonce from operating system: %v", err)
+	}
+	nonce := buf[nonceLen:]
+	b64Uri.Encode(nonce, buf[:nonceLen])
+	return nonce, nil
+}
+
+func scramGenerateSalt() ([]byte, error) {
+	const saltLen = 16
+	salt := make([]byte, saltLen)
+	if _, err := rand.Read(salt); err != nil {
+		return nil, fmt.Errorf("cannot read random SCRAM salt from operating system: %v", err)
+	}
+	return salt, nil
+}

--- a/client/Client_test.go
+++ b/client/Client_test.go
@@ -1,9 +1,13 @@
 package client
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -114,7 +118,188 @@ func (clientHTTPPlaintextAuth *clientHTTPPlaintextAuth) do(req *http.Request) (*
 	return &response, nil
 }
 
-// TODO: SCRAM
+func TestClientAuth_SCRAM(t *testing.T) {
+	mock := &clientHTTPScramAuth{}
+	client := &Client{
+		clientHTTP: mock,
+		uri:        "http://localhost:8080/api/demo/",
+		username:   "test",
+		password:   "test",
+	}
+
+	openErr := client.Open()
+	assert.Nil(t, openErr)
+	assert.Equal(t, "BEARER authToken=pretend-this-is-a-token", client.auth)
+}
+
+// clientHTTPScramAuth validates the SCRAM haystack authentication.
+// https://project-haystack.org/doc/docHaystack/Auth#scram
+type clientHTTPScramAuth struct {
+	clientNonce string
+}
+
+func (clientHTTPScramAuth *clientHTTPScramAuth) do(req *http.Request) (*http.Response, error) {
+	response := http.Response{
+		Header: make(http.Header),
+		Body:   http.NoBody,
+	}
+
+	switch req.Method {
+	case "GET":
+		authMsg := authMsgFromString(req.Header.Get("Authorization"))
+		switch authMsg.scheme {
+		case "HELLO":
+			if authMsg.attrs["username"] != "dGVzdA" {
+				return nil, errors.New("unexpected hello username")
+			}
+			response.StatusCode = http.StatusUnauthorized
+			response.Header.Set("WWW-Authenticate", "SCRAM hash=SHA-256, handshakeToken=step-1")
+			return &response, nil
+		case "SCRAM":
+			handshakeToken := authMsg.attrs["handshakeToken"]
+			data, err := encoding.DecodeString(authMsg.attrs["data"])
+			if err != nil {
+				return nil, err
+			}
+
+			switch handshakeToken {
+			case "step-1":
+				clientFirst := string(data)
+				if !strings.HasPrefix(clientFirst, "n,,n=test,r=") {
+					return nil, errors.New("unexpected SCRAM client first message")
+				}
+				clientNonce := strings.TrimPrefix(clientFirst, "n,,n=test,r=")
+				clientHTTPScramAuth.clientNonce = clientNonce
+				serverFirst := testScramServerFirstMessage(clientNonce)
+
+				response.StatusCode = http.StatusUnauthorized
+				response.Header.Set("WWW-Authenticate", authMsgToString("SCRAM", map[string]string{
+					"handshakeToken": "step-2",
+					"data":           encoding.EncodeToString([]byte(serverFirst)),
+				}))
+				return &response, nil
+			case "step-2":
+				clientFinal := string(data)
+				if err := testScramValidateClientFinal(clientHTTPScramAuth.clientNonce, clientFinal); err != nil {
+					return nil, err
+				}
+
+				response.StatusCode = http.StatusOK
+				response.Header.Set("Authentication-Info", authMsgToString("", map[string]string{
+					"handshakeToken": "step-3",
+					"authToken":      "pretend-this-is-a-token",
+					"data":           encoding.EncodeToString([]byte("v=" + testScramServerSignature(clientHTTPScramAuth.clientNonce))),
+				}))
+				return &response, nil
+			default:
+				return nil, errors.New("unexpected SCRAM handshake token")
+			}
+		case "BEARER":
+			if authMsg.attrs["authToken"] != "pretend-this-is-a-token" {
+				return nil, errors.New("unexpected bearer auth token")
+			}
+			response.StatusCode = http.StatusOK
+			return &response, nil
+		}
+	}
+
+	return &response, nil
+}
+
+func authMsgToString(scheme string, attrs map[string]string) string {
+	return (&authMsg{scheme: scheme, attrs: attrs}).toString()
+}
+
+func testScramServerFirstMessage(clientNonce string) string {
+	return "r=" + clientNonce + testScramServerNonceSuffix + ",s=" + testScramSaltB64 + ",i=" + strconv.Itoa(testScramIterations)
+}
+
+func testScramValidateClientFinal(clientNonce string, clientFinal string) error {
+	parts := strings.Split(clientFinal, ",")
+	if len(parts) != 3 {
+		return errors.New("unexpected SCRAM client final message")
+	}
+	if parts[0] != "c=biws" {
+		return errors.New("unexpected SCRAM channel binding")
+	}
+	if parts[1] != "r="+testScramCombinedNonce(clientNonce) {
+		return errors.New("unexpected SCRAM combined nonce")
+	}
+	if parts[2] != "p="+testScramClientProof(clientNonce) {
+		return errors.New("unexpected SCRAM client proof")
+	}
+	return nil
+}
+
+const (
+	testScramServerNonceSuffix = "servernonce"
+	testScramSalt             = "salt-for-tests"
+	testScramSaltB64          = "c2FsdC1mb3ItdGVzdHM="
+	testScramIterations       = 4096
+	testScramPassword         = "test"
+	testScramUsername         = "test"
+)
+
+func testScramCombinedNonce(clientNonce string) string {
+	return clientNonce + testScramServerNonceSuffix
+}
+
+func testScramClientFirstBare(clientNonce string) string {
+	return "n=" + testScramUsername + ",r=" + clientNonce
+}
+
+func testScramClientProof(clientNonce string) string {
+	clientFinalWithoutProof := "c=biws,r=" + testScramCombinedNonce(clientNonce)
+	authMessage := testScramClientFirstBare(clientNonce) + "," + testScramServerFirstMessage(clientNonce) + "," + clientFinalWithoutProof
+	saltedPassword := testScramSaltPassword([]byte(testScramSalt), testScramIterations, testScramPassword)
+
+	clientKey := testScramHMAC(saltedPassword, []byte("Client Key"))
+	storedKey := testScramSHA256(clientKey)
+	clientSignature := testScramHMAC(storedKey, []byte(authMessage))
+	clientProof := make([]byte, len(clientKey))
+	for i := range clientKey {
+		clientProof[i] = clientKey[i] ^ clientSignature[i]
+	}
+	return base64.StdEncoding.EncodeToString(clientProof)
+}
+
+func testScramServerSignature(clientNonce string) string {
+	clientFinalWithoutProof := "c=biws,r=" + testScramCombinedNonce(clientNonce)
+	authMessage := testScramClientFirstBare(clientNonce) + "," + testScramServerFirstMessage(clientNonce) + "," + clientFinalWithoutProof
+	saltedPassword := testScramSaltPassword([]byte(testScramSalt), testScramIterations, testScramPassword)
+	serverKey := testScramHMAC(saltedPassword, []byte("Server Key"))
+	serverSignature := testScramHMAC(serverKey, []byte(authMessage))
+	return base64.StdEncoding.EncodeToString(serverSignature)
+}
+
+func testScramSaltPassword(salt []byte, iterCount int, password string) []byte {
+	mac := hmac.New(sha256.New, []byte(password))
+	mac.Write(salt)
+	mac.Write([]byte{0, 0, 0, 1})
+	ui := mac.Sum(nil)
+	hi := make([]byte, len(ui))
+	copy(hi, ui)
+	for i := 1; i < iterCount; i++ {
+		mac.Reset()
+		mac.Write(ui)
+		mac.Sum(ui[:0])
+		for j, b := range ui {
+			hi[j] ^= b
+		}
+	}
+	return hi
+}
+
+func testScramHMAC(key, data []byte) []byte {
+	mac := hmac.New(sha256.New, key)
+	mac.Write(data)
+	return mac.Sum(nil)
+}
+
+func testScramSHA256(data []byte) []byte {
+	hash := sha256.Sum256(data)
+	return hash[:]
+}
 
 func TestClient_Open(t *testing.T) {
 	client := testPostClient()

--- a/client/Client_test.go
+++ b/client/Client_test.go
@@ -1,16 +1,14 @@
 package client
 
 import (
-	"crypto/hmac"
 	"crypto/sha256"
-	"encoding/base64"
 	"errors"
 	"io/ioutil"
 	"net/http"
-	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/NeedleInAJayStack/haystack/auth"
 	"github.com/NeedleInAJayStack/haystack"
 	"github.com/NeedleInAJayStack/haystack/io"
 	"github.com/stretchr/testify/assert"
@@ -135,7 +133,7 @@ func TestClientAuth_SCRAM(t *testing.T) {
 // clientHTTPScramAuth validates the SCRAM haystack authentication.
 // https://project-haystack.org/doc/docHaystack/Auth#scram
 type clientHTTPScramAuth struct {
-	clientNonce string
+	server *auth.ScramServer
 }
 
 func (clientHTTPScramAuth *clientHTTPScramAuth) do(req *http.Request) (*http.Response, error) {
@@ -152,10 +150,17 @@ func (clientHTTPScramAuth *clientHTTPScramAuth) do(req *http.Request) (*http.Res
 			if reqAuth.attrs["username"] != "dGVzdA" {
 				return nil, errors.New("unexpected hello username")
 			}
+			clientHTTPScramAuth.server = auth.NewScramServer(sha256.New, "test", "test")
+			clientHTTPScramAuth.server.SetNonce([]byte("servernonce"))
+			clientHTTPScramAuth.server.SetSalt([]byte("salt-for-tests"))
+			clientHTTPScramAuth.server.SetIterations(4096)
 			response.StatusCode = http.StatusUnauthorized
 			response.Header.Set("WWW-Authenticate", "SCRAM hash=SHA-256, handshakeToken=step-1")
 			return &response, nil
 		case "SCRAM":
+			if clientHTTPScramAuth.server == nil {
+				return nil, errors.New("SCRAM server not initialized")
+			}
 			handshakeToken := reqAuth.attrs["handshakeToken"]
 			data, err := encoding.DecodeString(reqAuth.attrs["data"])
 			if err != nil {
@@ -164,42 +169,34 @@ func (clientHTTPScramAuth *clientHTTPScramAuth) do(req *http.Request) (*http.Res
 
 			switch handshakeToken {
 			case "step-1":
-				clientFirst := string(data)
-				if !strings.HasPrefix(clientFirst, "n,,n=test,r=") {
-					return nil, errors.New("unexpected SCRAM client first message")
+				done := clientHTTPScramAuth.server.Step(data)
+				if done {
+					return nil, errors.New("unexpected SCRAM server completion")
 				}
-				clientNonce := strings.TrimPrefix(clientFirst, "n,,n=test,r=")
-				clientHTTPScramAuth.clientNonce = clientNonce
-				serverFirst := testScramServerFirstMessage(clientNonce)
+				if err := clientHTTPScramAuth.server.Err(); err != nil {
+					return nil, err
+				}
 
 				response.StatusCode = http.StatusUnauthorized
 				response.Header.Set("WWW-Authenticate", (&authMsg{scheme: "SCRAM", attrs: map[string]string{
 					"handshakeToken": "step-2",
-					"data":           encoding.EncodeToString([]byte(serverFirst)),
+					"data":           encoding.EncodeToString(clientHTTPScramAuth.server.Out()),
 				}}).toString())
 				return &response, nil
 			case "step-2":
-				clientFinal := string(data)
-				parts := strings.Split(clientFinal, ",")
-				if len(parts) != 3 {
-					return nil, errors.New("unexpected SCRAM client final message")
+				done := clientHTTPScramAuth.server.Step(data)
+				if !done {
+					return nil, errors.New("expected SCRAM server completion")
 				}
-				if parts[0] != "c=biws" {
-					return nil, errors.New("unexpected SCRAM channel binding")
-				}
-				combinedNonce := clientHTTPScramAuth.clientNonce + testScramServerNonceSuffix
-				if parts[1] != "r="+combinedNonce {
-					return nil, errors.New("unexpected SCRAM combined nonce")
-				}
-				if parts[2] != "p="+testScramClientProof(clientHTTPScramAuth.clientNonce) {
-					return nil, errors.New("unexpected SCRAM client proof")
+				if err := clientHTTPScramAuth.server.Err(); err != nil {
+					return nil, err
 				}
 
 				response.StatusCode = http.StatusOK
 				response.Header.Set("Authentication-Info", (&authMsg{attrs: map[string]string{
 					"handshakeToken": "step-3",
 					"authToken":      "pretend-this-is-a-token",
-					"data":           encoding.EncodeToString([]byte("v=" + testScramServerSignature(clientHTTPScramAuth.clientNonce))),
+					"data":           encoding.EncodeToString(clientHTTPScramAuth.server.Out()),
 				}}).toString())
 				return &response, nil
 			default:
@@ -215,68 +212,6 @@ func (clientHTTPScramAuth *clientHTTPScramAuth) do(req *http.Request) (*http.Res
 	}
 
 	return &response, nil
-}
-
-func testScramServerFirstMessage(clientNonce string) string {
-	return "r=" + clientNonce + testScramServerNonceSuffix + ",s=" + testScramSaltB64 + ",i=" + strconv.Itoa(testScramIterations)
-}
-
-const (
-	testScramServerNonceSuffix = "servernonce"
-	testScramSalt             = "salt-for-tests"
-	testScramSaltB64          = "c2FsdC1mb3ItdGVzdHM="
-	testScramIterations       = 4096
-	testScramPassword         = "test"
-	testScramUsername         = "test"
-)
-
-func testScramClientProof(clientNonce string) string {
-	clientFinalWithoutProof := "c=biws,r=" + clientNonce + testScramServerNonceSuffix
-	authMessage := "n=" + testScramUsername + ",r=" + clientNonce + "," + testScramServerFirstMessage(clientNonce) + "," + clientFinalWithoutProof
-	saltedPassword := testScramSaltPassword([]byte(testScramSalt), testScramIterations, testScramPassword)
-
-	clientKey := testScramHMAC(saltedPassword, []byte("Client Key"))
-	storedKey := sha256.Sum256(clientKey)
-	storedKeyBytes := storedKey[:]
-	clientSignature := testScramHMAC(storedKeyBytes, []byte(authMessage))
-	clientProof := make([]byte, len(clientKey))
-	for i := range clientKey {
-		clientProof[i] = clientKey[i] ^ clientSignature[i]
-	}
-	return base64.StdEncoding.EncodeToString(clientProof)
-}
-
-func testScramServerSignature(clientNonce string) string {
-	clientFinalWithoutProof := "c=biws,r=" + clientNonce + testScramServerNonceSuffix
-	authMessage := "n=" + testScramUsername + ",r=" + clientNonce + "," + testScramServerFirstMessage(clientNonce) + "," + clientFinalWithoutProof
-	saltedPassword := testScramSaltPassword([]byte(testScramSalt), testScramIterations, testScramPassword)
-	serverKey := testScramHMAC(saltedPassword, []byte("Server Key"))
-	serverSignature := testScramHMAC(serverKey, []byte(authMessage))
-	return base64.StdEncoding.EncodeToString(serverSignature)
-}
-
-func testScramSaltPassword(salt []byte, iterCount int, password string) []byte {
-	mac := hmac.New(sha256.New, []byte(password))
-	mac.Write(salt)
-	mac.Write([]byte{0, 0, 0, 1})
-	ui := mac.Sum(nil)
-	hi := make([]byte, len(ui))
-	copy(hi, ui)
-	for i := 1; i < iterCount; i++ {
-		mac.Reset()
-		mac.Write(ui)
-		mac.Sum(ui[:0])
-		for j, b := range ui {
-			hi[j] ^= b
-		}
-	}
-	return hi
-}
-
-func testScramHMAC(key, data []byte) []byte {
-	mac := hmac.New(sha256.New, key)
-	mac.Write(data)
-	return mac.Sum(nil)
 }
 
 

--- a/client/Client_test.go
+++ b/client/Client_test.go
@@ -146,18 +146,18 @@ func (clientHTTPScramAuth *clientHTTPScramAuth) do(req *http.Request) (*http.Res
 
 	switch req.Method {
 	case "GET":
-		authMsg := authMsgFromString(req.Header.Get("Authorization"))
-		switch authMsg.scheme {
+		reqAuth := authMsgFromString(req.Header.Get("Authorization"))
+		switch reqAuth.scheme {
 		case "HELLO":
-			if authMsg.attrs["username"] != "dGVzdA" {
+			if reqAuth.attrs["username"] != "dGVzdA" {
 				return nil, errors.New("unexpected hello username")
 			}
 			response.StatusCode = http.StatusUnauthorized
 			response.Header.Set("WWW-Authenticate", "SCRAM hash=SHA-256, handshakeToken=step-1")
 			return &response, nil
 		case "SCRAM":
-			handshakeToken := authMsg.attrs["handshakeToken"]
-			data, err := encoding.DecodeString(authMsg.attrs["data"])
+			handshakeToken := reqAuth.attrs["handshakeToken"]
+			data, err := encoding.DecodeString(reqAuth.attrs["data"])
 			if err != nil {
 				return nil, err
 			}
@@ -173,29 +173,40 @@ func (clientHTTPScramAuth *clientHTTPScramAuth) do(req *http.Request) (*http.Res
 				serverFirst := testScramServerFirstMessage(clientNonce)
 
 				response.StatusCode = http.StatusUnauthorized
-				response.Header.Set("WWW-Authenticate", authMsgToString("SCRAM", map[string]string{
+				response.Header.Set("WWW-Authenticate", (&authMsg{scheme: "SCRAM", attrs: map[string]string{
 					"handshakeToken": "step-2",
 					"data":           encoding.EncodeToString([]byte(serverFirst)),
-				}))
+				}}).toString())
 				return &response, nil
 			case "step-2":
 				clientFinal := string(data)
-				if err := testScramValidateClientFinal(clientHTTPScramAuth.clientNonce, clientFinal); err != nil {
-					return nil, err
+				parts := strings.Split(clientFinal, ",")
+				if len(parts) != 3 {
+					return nil, errors.New("unexpected SCRAM client final message")
+				}
+				if parts[0] != "c=biws" {
+					return nil, errors.New("unexpected SCRAM channel binding")
+				}
+				combinedNonce := clientHTTPScramAuth.clientNonce + testScramServerNonceSuffix
+				if parts[1] != "r="+combinedNonce {
+					return nil, errors.New("unexpected SCRAM combined nonce")
+				}
+				if parts[2] != "p="+testScramClientProof(clientHTTPScramAuth.clientNonce) {
+					return nil, errors.New("unexpected SCRAM client proof")
 				}
 
 				response.StatusCode = http.StatusOK
-				response.Header.Set("Authentication-Info", authMsgToString("", map[string]string{
+				response.Header.Set("Authentication-Info", (&authMsg{attrs: map[string]string{
 					"handshakeToken": "step-3",
 					"authToken":      "pretend-this-is-a-token",
 					"data":           encoding.EncodeToString([]byte("v=" + testScramServerSignature(clientHTTPScramAuth.clientNonce))),
-				}))
+				}}).toString())
 				return &response, nil
 			default:
 				return nil, errors.New("unexpected SCRAM handshake token")
 			}
 		case "BEARER":
-			if authMsg.attrs["authToken"] != "pretend-this-is-a-token" {
+			if reqAuth.attrs["authToken"] != "pretend-this-is-a-token" {
 				return nil, errors.New("unexpected bearer auth token")
 			}
 			response.StatusCode = http.StatusOK
@@ -206,29 +217,8 @@ func (clientHTTPScramAuth *clientHTTPScramAuth) do(req *http.Request) (*http.Res
 	return &response, nil
 }
 
-func authMsgToString(scheme string, attrs map[string]string) string {
-	return (&authMsg{scheme: scheme, attrs: attrs}).toString()
-}
-
 func testScramServerFirstMessage(clientNonce string) string {
 	return "r=" + clientNonce + testScramServerNonceSuffix + ",s=" + testScramSaltB64 + ",i=" + strconv.Itoa(testScramIterations)
-}
-
-func testScramValidateClientFinal(clientNonce string, clientFinal string) error {
-	parts := strings.Split(clientFinal, ",")
-	if len(parts) != 3 {
-		return errors.New("unexpected SCRAM client final message")
-	}
-	if parts[0] != "c=biws" {
-		return errors.New("unexpected SCRAM channel binding")
-	}
-	if parts[1] != "r="+testScramCombinedNonce(clientNonce) {
-		return errors.New("unexpected SCRAM combined nonce")
-	}
-	if parts[2] != "p="+testScramClientProof(clientNonce) {
-		return errors.New("unexpected SCRAM client proof")
-	}
-	return nil
 }
 
 const (
@@ -240,22 +230,15 @@ const (
 	testScramUsername         = "test"
 )
 
-func testScramCombinedNonce(clientNonce string) string {
-	return clientNonce + testScramServerNonceSuffix
-}
-
-func testScramClientFirstBare(clientNonce string) string {
-	return "n=" + testScramUsername + ",r=" + clientNonce
-}
-
 func testScramClientProof(clientNonce string) string {
-	clientFinalWithoutProof := "c=biws,r=" + testScramCombinedNonce(clientNonce)
-	authMessage := testScramClientFirstBare(clientNonce) + "," + testScramServerFirstMessage(clientNonce) + "," + clientFinalWithoutProof
+	clientFinalWithoutProof := "c=biws,r=" + clientNonce + testScramServerNonceSuffix
+	authMessage := "n=" + testScramUsername + ",r=" + clientNonce + "," + testScramServerFirstMessage(clientNonce) + "," + clientFinalWithoutProof
 	saltedPassword := testScramSaltPassword([]byte(testScramSalt), testScramIterations, testScramPassword)
 
 	clientKey := testScramHMAC(saltedPassword, []byte("Client Key"))
-	storedKey := testScramSHA256(clientKey)
-	clientSignature := testScramHMAC(storedKey, []byte(authMessage))
+	storedKey := sha256.Sum256(clientKey)
+	storedKeyBytes := storedKey[:]
+	clientSignature := testScramHMAC(storedKeyBytes, []byte(authMessage))
 	clientProof := make([]byte, len(clientKey))
 	for i := range clientKey {
 		clientProof[i] = clientKey[i] ^ clientSignature[i]
@@ -264,8 +247,8 @@ func testScramClientProof(clientNonce string) string {
 }
 
 func testScramServerSignature(clientNonce string) string {
-	clientFinalWithoutProof := "c=biws,r=" + testScramCombinedNonce(clientNonce)
-	authMessage := testScramClientFirstBare(clientNonce) + "," + testScramServerFirstMessage(clientNonce) + "," + clientFinalWithoutProof
+	clientFinalWithoutProof := "c=biws,r=" + clientNonce + testScramServerNonceSuffix
+	authMessage := "n=" + testScramUsername + ",r=" + clientNonce + "," + testScramServerFirstMessage(clientNonce) + "," + clientFinalWithoutProof
 	saltedPassword := testScramSaltPassword([]byte(testScramSalt), testScramIterations, testScramPassword)
 	serverKey := testScramHMAC(saltedPassword, []byte("Server Key"))
 	serverSignature := testScramHMAC(serverKey, []byte(authMessage))
@@ -296,10 +279,6 @@ func testScramHMAC(key, data []byte) []byte {
 	return mac.Sum(nil)
 }
 
-func testScramSHA256(data []byte) []byte {
-	hash := sha256.Sum256(data)
-	return hash[:]
-}
 
 func TestClient_Open(t *testing.T) {
 	client := testPostClient()


### PR DESCRIPTION
It does this by adding a Server-side SCRAM implementation in `ScramServer`, and using that implementation in the client tests.